### PR TITLE
Version 5.0.6

### DIFF
--- a/whirlpool_plus.meta.js
+++ b/whirlpool_plus.meta.js
@@ -2,7 +2,7 @@
 // @name            Whirlpool Plus
 // @namespace       WhirlpoolPlus
 // @description     Adds a suite of extra optional features to the Whirlpool forums.
-// @version         5.0.5
+// @version         5.0.6
 // @updateURL       https://raw.githubusercontent.com/endorph-soft/wpplus/master/whirlpool_plus.meta.js
 // @downloadURL     https://raw.githubusercontent.com/endorph-soft/wpplus/master/whirlpool_plus.user.js
 // @grant           unsafeWindow


### PR DESCRIPTION
Fixes:
Floating Top Bar with no background now has a semi-transparent
background unless another colour is specified in a CSS theme
Tinypic link for avatar uploads now works again

Changes:
"Open Watched Threads In Tabs" buttons can now be turned off, though
this is on by default

Adds:
Increased spacing between buttons on Watched Threads page
Toggle to reverse the positioning of the "Mark as Read/Stop Watching
Checked" buttons on the Watched Threads page
Return to last page after sign-in (off by default, must be enabled on
both whirlpool.net.au and forums.whirlpool.net.au domains for proper
operation)