### PR TITLE
Version 2021.4.1

### DIFF
--- a/whirlpool_plus.meta.js
+++ b/whirlpool_plus.meta.js
@@ -2,7 +2,7 @@
 // @name            Whirlpool Plus
 // @namespace       WhirlpoolPlus
 // @description     Adds a suite of extra optional features to the Whirlpool forums.
-// @version         2021.4.0
+// @version         2021.4.1
 // @updateURL       https://raw.githubusercontent.com/endorph-soft/wpplus/master/whirlpool_plus.meta.js
 // @downloadURL     https://raw.githubusercontent.com/endorph-soft/wpplus/master/whirlpool_plus.user.js
 // @grant           unsafeWindow


### PR DESCRIPTION
Changes:
Removed old 'Mark as Read' method for Watched Threads
Integrated 'Mark as Read' actions with new method.
Updates WLR 'go to end' arrow buttons tooltip text to not replace existing Whirlpool tooltips
Adds tooltips to WLR read and unread colour gradients
Updates storage prefix for WLR Sync Data - if you are using multiple installations of WP+ ensure they are all updated as this breaks backwards compatibility with previous versions